### PR TITLE
be compatible with Scala 2.12.0-M4

### DIFF
--- a/core/src/generic.scala
+++ b/core/src/generic.scala
@@ -89,7 +89,7 @@ trait Generic extends CoreProtocol{
   def withStamp[S, T](stamp : S)(binary : Format[T])(implicit binS : Format[S]) : Format[T] = new Format[T]{
     def reads(in : Input) = {
       val datastamp = read[S](in);
-      if (stamp != datastamp) error("Incorrect stamp. Expected: " + stamp + ", Found: " + datastamp);
+      if (stamp != datastamp) sys.error("Incorrect stamp. Expected: " + stamp + ", Found: " + datastamp);
       binary.reads(in);
     }
 
@@ -145,7 +145,7 @@ trait Generic extends CoreProtocol{
    * Uses a single tag byte to represent S as a union of subtypes. 
    */
   def asUnion[S](summands : Summand[_ <: S]*) : Format[S] = 
-    if (summands.length >= 256) error("Sums of 256 or more elements currently not supported");
+    if (summands.length >= 256) sys.error("Sums of 256 or more elements currently not supported");
     else
     new Format[S]{
       val mappings = summands.toArray.zipWithIndex;
@@ -155,7 +155,7 @@ trait Generic extends CoreProtocol{
       def writes(out : Output, s : S): Unit =
         mappings.find(_._1.clazz.isInstance(s)) match {
           case Some( (sum, i) ) => writeSum(out, s, sum, i)
-          case None => error("No known sum type for object " + s);
+          case None => sys.error("No known sum type for object " + s);
         }
       private def writeSum[T](out : Output, s : S, sum : Summand[T], i : Int) {
         write(out, i.toByte);

--- a/core/src/javaprotocol.scala
+++ b/core/src/javaprotocol.scala
@@ -106,8 +106,8 @@ trait JavaUTF extends CoreProtocol{
 
       var count, charCount, c, char2, char3 = 0;
 
-      def malformed(index : Int) = error("Malformed input around byte " + index);
-      def partial = error("Malformed input: Partial character at end");
+      def malformed(index : Int) = sys.error("Malformed input around byte " + index);
+      def partial = sys.error("Malformed input: Partial character at end");
 
       while((count < utflen) && {c = bbuffer(count) & 0xff; c <= 127 }) {
         cbuffer(charCount) = c.toChar;
@@ -162,7 +162,7 @@ trait JavaUTF extends CoreProtocol{
       }
      
 	    if (utflen > 65535)
-        error("encoded string too long: " + utflen + " bytes");
+        sys.error("encoded string too long: " + utflen + " bytes");
 
       val bbuffer = fetchBuffers(utflen + 2)._2;
       var count = 0;

--- a/core/src/standardtypes.scala
+++ b/core/src/standardtypes.scala
@@ -48,7 +48,7 @@ trait LowPriorityCollectionTypes extends Generic {
         val builder = cbf.apply()
         builder.sizeHint(length)
         builder ++= ts
-		  if(ts.hasNext) error("Builder did not consume all input.") // no lazy builders allowed
+		  if(ts.hasNext) sys.error("Builder did not consume all input.") // no lazy builders allowed
         builder.result()
       } 
     }


### PR DESCRIPTION
note that the change is backward compatible at least to Scala 2.9

I have changed the Scala community build to include sbt/sbinary now instead of harrah/sbinary, so it would be nice to have this merged so we don't need to use my private fork on sbt/sbinary in the community build.