### PR TITLE
Add methods asProduct10 to asProduct21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val root = (project in file("."))
         organization := "org.scala-sbt",
         organizationHomepage := Some(url("http://scala-sbt.org/")),
         homepage := Some(url("https://github.com/sbt/sbinary")),
-        version := "0.4.5-SNAPSHOT",
+        version := "0.5.0-SNAPSHOT",
         scalaVersion := "2.12.4",
         crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.4", "2.13.0-M4"),
         bintrayPackage := "sbinary",
@@ -66,16 +66,7 @@ lazy val core = (project in file("core")).settings(
   relaxOldScala,
   Fmpp.templateSettings,
   mimaPreviousArtifacts := {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= 13 =>
-        Set.empty
-      case _ =>
-        Set(
-          "0.4.4"
-        ).map { v =>
-          organization.value %% moduleName.value % v
-        }
-    }
+    Set.empty
   },
   libraryDependencies += scalacheck % Test,
   libraryDependencies ++= scalaVersion(scalaXmlDep).value,

--- a/core/src/main/fmpp/generic.scala
+++ b/core/src/main/fmpp/generic.scala
@@ -108,7 +108,7 @@ trait Generic extends CoreProtocol{
     def writes(out : Output, value : V) = write(out, value.id)
   }
 
-  <#list 2..9 as i> 
+  <#list 2..21 as i> 
   <#assign typeParams><#list 1..i as j>T${j}<#if i !=j>,</#if></#list></#assign>
   /**
    * Represents this type as ${i} consecutive binary blocks of type T1..T${i},


### PR DESCRIPTION
After https://github.com/sbt/util/pull/173, Position now has 13 fields
so TextAnalysisFormat in Zinc needs asProduct13. While we're at it we
bump the max to 21 to give us some legroom.