### PR TITLE
support Scala 2.13.0, modernize versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: scala
 
 script:
@@ -8,13 +6,13 @@ script:
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.7
-  - 2.13.0-M4
+  - 2.12.8
+  - 2.13.0
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 matrix:
   include:
   - jdk: openjdk11
-    scala: 2.12.7
+    scala: 2.12.8

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ def scalaXmlDep(scalaV: String): List[ModuleID] =
     case Some((2, 11 | 12)) =>
       List("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
     case _ =>
-      List("org.scala-lang.modules" %% "scala-xml" % "1.1.0")
+      List("org.scala-lang.modules" %% "scala-xml" % "1.2.0")
   }
 
 def relaxOldScala: Seq[Setting[_]] = Seq(

--- a/core/src/main/fmpp/generic.scala
+++ b/core/src/main/fmpp/generic.scala
@@ -148,7 +148,7 @@ trait Generic extends CoreProtocol{
     new Format[S]{
       val mappings = summands.toArray.zipWithIndex;
 
-      def reads(in : Input) : S = read(in)(summands(read[Byte](in)).format)
+      def reads(in : Input) : S = read(in)(summands(read[Byte](in).toInt).format)
 
       def writes(out : Output, s : S): Unit =
         mappings.find(_._1.clazz.isInstance(s)) match {

--- a/core/src/main/scala/io.scala
+++ b/core/src/main/scala/io.scala
@@ -79,7 +79,7 @@ class JavaInput(in: InputStream) extends Input {
 }
 
 class JavaOutput(out: OutputStream) extends Output {
-  def writeByte(value: Byte) = out.write(value);
+  def writeByte(value: Byte) = out.write(value.toInt)
   override def writeAll(source: Array[Byte], offset: Int, length: Int) =
     out.write(source, offset, length);
 }

--- a/core/src/main/scala/javaprotocol.scala
+++ b/core/src/main/scala/javaprotocol.scala
@@ -126,14 +126,14 @@ trait JavaUTF extends CoreProtocol {
             count += 2;
             if (count > utflen) partial;
 
-            char2 = bbuffer(count - 1)
+            char2 = bbuffer(count - 1).toInt
             if ((char2 & 0xC0) != 0x80) malformed(count);
             (((c & 0x1F) << 6) | (char2 & 0x3F));
           }
           case 14 => {
             count += 3;
-            char2 = bbuffer(count - 2);
-            char3 = bbuffer(count - 1);
+            char2 = bbuffer(count - 2).toInt
+            char3 = bbuffer(count - 1).toInt
             if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
               malformed(count - 1);
 
@@ -184,7 +184,7 @@ trait JavaUTF extends CoreProtocol {
 
       while (i < value.length) {
         if ((c >= 0x0001) && (c <= 0x007F)) {
-          append(c);
+          append(c.toInt);
         } else if (c > 0x07FF) {
           append(0xE0 | ((c >> 12) & 0x0F));
           append(0x80 | ((c >> 6) & 0x3F));

--- a/core/src/test/scala/binaryTests.scala
+++ b/core/src/test/scala/binaryTests.scala
@@ -103,7 +103,7 @@ object CompatTests extends Properties("CompatTests") {
   compatFor[String]("String", _.readUTF, _.writeUTF(_))
   compatFor[Long]("Long", _.readLong, _.writeLong(_))
   compatFor[Int]("Int", _.readInt, _.writeInt(_))
-  compatFor[Byte]("Byte", _.readByte, _.writeByte(_))
+  compatFor[Byte]("Byte", _.readByte, (out, b) => out.writeByte(b.toInt))
   compatFor[Double]("Double", _.readDouble, _.writeDouble(_))
   compatFor[Boolean]("Boolean", _.readBoolean, _.writeBoolean(_))
 }

--- a/project/houserules.sbt
+++ b/project/houserules.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.5")
+addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.9")


### PR DESCRIPTION
nbd, but the sbt-houserules bump would be convenient in the Scala community build,
where the old version of scalafmt that the old sbt-houserules
brings in is troublesome