### PR TITLE
Fix `Line is indented too far to the left` warnings

### DIFF
--- a/core/src/main/fmpp/generic.scala
+++ b/core/src/main/fmpp/generic.scala
@@ -118,7 +118,7 @@ trait Generic extends CoreProtocol{
    <#list 1..i as j>
       bin${j} : Format[T${j}] <#if i != j>,</#if>
     </#list>) = new Format[S]{
-       def reads (in : Input) : S = apply(
+      def reads (in : Input) : S = apply(
       <#list 1..i as j>
          read[T${j}](in)<#if i != j>,</#if>
       </#list>
@@ -127,8 +127,8 @@ trait Generic extends CoreProtocol{
       def writes(out : Output, s : S) = {
         val product = unapply(s);
         <#list 1..i as j>
-          write(out, product._${j});
-        </#list>;       
+        write(out, product._${j});
+        </#list>
       }
     }  
 </#list>

--- a/core/src/main/fmpp/standardtypes.scala
+++ b/core/src/main/fmpp/standardtypes.scala
@@ -17,9 +17,7 @@ trait BasicTypes extends CoreProtocol{
   }
 
 <#list 2..22 as i>
-  <#assign typeName>
-   Tuple${i}[<#list 1..i as j>T${j} <#if i != j>,</#if></#list>]
-  </#assign>
+  <#assign typeName>Tuple${i}[<#list 1..i as j>T${j} <#if i != j>,</#if></#list>]</#assign>
   implicit def tuple${i}Format[<#list 1..i as j>T${j}<#if i !=j>,</#if></#list>](implicit 
     <#list 1..i as j>
       bin${j} : Format[T${j}] <#if i != j>,</#if>
@@ -33,8 +31,8 @@ trait BasicTypes extends CoreProtocol{
     
       def writes(out : Output, tuple : ${typeName}) = {
       <#list 1..i as j>
-        write(out, tuple._${j});      
-      </#list>;
+        write(out, tuple._${j});
+      </#list>
       }
   }
 </#list>


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/target/scala-3.3.7/src_managed/main/generic.scala:124:6 
[warn] 124 |      def writes(out : Output, s : S) = {
[warn]     |      ^
[warn]     |      Line is indented too far to the left, or a `}` is missing
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/target/scala-3.3.7/src_managed/main/generic.scala:146:6 
[warn] 146 |      def writes(out : Output, s : S) = {
[warn]     |      ^
[warn]     |      Line is indented too far to the left, or a `}` is missing
```

```
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/target/scala-3.3.7/src_managed/main/standardtypes.scala:26:1 
[warn] 26 | = ( 
[warn]    | ^
[warn]    | Line is indented too far to the left, or a `}` is missing
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/target/scala-3.3.7/src_managed/main/standardtypes.scala:35:6 
[warn] 35 |      ;
[warn]    |      ^
[warn]    |      Line is indented too far to the left, or a `}` is missing
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/target/scala-3.3.7/src_managed/main/standardtypes.scala:46:1 
[warn] 46 | = ( 
[warn]    | ^
[warn]    | Line is indented too far to the left, or a `}` is missing
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/target/scala-3.3.7/src_managed/main/standardtypes.scala:57:6 
[warn] 57 |      ;
[warn]    |      ^
[warn]    |      Line is indented too far to the left, or a `}` is missing
```