### PR TITLE
Fix `apply auto insertion` warnings

### DIFF
--- a/core/src/test/scala/binaryTests.scala
+++ b/core/src/test/scala/binaryTests.scala
@@ -187,8 +187,8 @@ object FormatTests extends Properties("Formats") {
 
   implicit val eqFoo: Equal[Foo] = allAreEqual[Foo]
 
-  implicit val BazFormat: Format[Baz] = viaString(Baz)
-  implicit val BifFormat: Format[Bif] = asProduct2(Bif)(x => (x.i, x.j))
+  implicit val BazFormat: Format[Baz] = viaString(Baz.apply)
+  implicit val BifFormat: Format[Bif] = asProduct2(Bif.apply)(x => (x.i, x.j))
   implicit val FooFormat: Format[Foo] = asUnion[Foo](Bar, classOf[Baz], classOf[Bif])
 
   implicit val arbitraryFoo: Arbitrary[Foo] = Arbitrary[Foo](


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/src/test/scala/binaryTests.scala:190:50 
[warn] 190 |  implicit val BazFormat: Format[Baz] = viaString(Baz)
[warn]     |                                                  ^^^
[warn]     |The method `apply` is inserted. The auto insertion will be deprecated, please write `sbinary.FormatTests.Baz.apply` explicitly.
[warn] -- Warning: /home/runner/work/sbinary/sbinary/core/src/test/scala/binaryTests.scala:191:51 
[warn] 191 |  implicit val BifFormat: Format[Bif] = asProduct2(Bif)(x => (x.i, x.j))
[warn]     |                                                   ^^^
[warn]     |The method `apply` is inserted. The auto insertion will be deprecated, please write `sbinary.FormatTests.Bif.apply` explicitly.
```