### PR TITLE
Fix postfix warning in `project/Fmpp.scala`

### DIFF
--- a/project/Fmpp.scala
+++ b/project/Fmpp.scala
@@ -8,7 +8,7 @@ object Fmpp {
    */
   lazy val fmpp = TaskKey[Seq[File]]("fmpp")
   lazy val fmppOptions = SettingKey[Seq[String]]("fmpp-options")
-  lazy val FmppConfig = config("fmpp") hide
+  lazy val FmppConfig = config("fmpp").hide
 
   lazy val templateSettings = fmppConfig(Test) ++ fmppConfig(Compile) ++ templateBase
   lazy val templateBase = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
 addSbtPlugin("com.eed3si9n" % "sbt-nocomma" % "0.1.2")
+
+scalacOptions += "-feature"


### PR DESCRIPTION
```
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scaladoc for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]   lazy val FmppConfig = config("fmpp") hide
[warn]                                        ^
```